### PR TITLE
Fix: Enable cocoa bean replanting when holding an axe

### DIFF
--- a/Common/src/main/java/com/natamus/replantingcrops/config/ConfigHandler.java
+++ b/Common/src/main/java/com/natamus/replantingcrops/config/ConfigHandler.java
@@ -10,11 +10,11 @@ import java.util.List;
 public class ConfigHandler extends DuskConfig {
 	public static HashMap<String, List<String>> configMetaData = new HashMap<String, List<String>>();
 
-	@Entry public static boolean mustHoldHoeForReplanting = true;
+	@Entry public static boolean mustHoldToolForReplanting = true;
 
 	public static void initConfig() {
-		configMetaData.put("mustHoldHoeForReplanting", Arrays.asList(
-			"If enabled, players must hold a hoe in their hand to automatically replant the crop."
+		configMetaData.put("mustHoldToolForReplanting", Arrays.asList(
+			"If enabled, players must hold a hoe/axe in their hand to automatically replant the crop."
 		));
 
 		DuskConfig.init(Reference.NAME, Reference.MOD_ID, ConfigHandler.class);

--- a/Common/src/main/java/com/natamus/replantingcrops/events/CropEvent.java
+++ b/Common/src/main/java/com/natamus/replantingcrops/events/CropEvent.java
@@ -37,11 +37,11 @@ public class CropEvent {
 		}
 		
 		InteractionHand hand = null;
-		if (ConfigHandler.mustHoldHoeForReplanting) {
+		if (ConfigHandler.mustHoldToolForReplanting) {
 			hand = InteractionHand.MAIN_HAND;
-			if (!Services.TOOLFUNCTIONS.isHoe(player.getMainHandItem())) {
+			if (!Services.TOOLFUNCTIONS.isHoe(player.getMainHandItem()) && !Services.TOOLFUNCTIONS.isAxe(player.getMainHandItem())) {
 				hand = InteractionHand.OFF_HAND;
-				if (!Services.TOOLFUNCTIONS.isHoe(player.getOffhandItem())) {
+				if (!Services.TOOLFUNCTIONS.isHoe(player.getOffhandItem()) && !Services.TOOLFUNCTIONS.isAxe(player.getOffhandItem())) {
 					return true;
 				}
 			}


### PR DESCRIPTION
**Problem**: When mustHoldHoeForReplanting is enabled in the config, axes are not checked, leading to cocoa beans not being replanted when holding axes.

**Changes**: 
- Renamed config option 'mustHoldHoeForReplanting' to 'mustHoldToolForReplanting'
- Added 'isAxe' check for main/off hand

**Further Improvements**: These changes would mean that axes can also replant non-cocoa crops, but I don't see this as a problem as hoes could replant cocoa beans in the original branch. A fix for this could be to separate the isHoe and isAxe checks to match their respective crops.